### PR TITLE
chore: bump jsbeautify to latest tag

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,6 @@
   language: node
   files: \.js$
   args: []
-  additional_dependencies: ['js-beautify@1.13.0']
+  additional_dependencies: ['js-beautify@1.14.7']
   minimum_pre_commit_version: 2.7.1
   description: "Runs `js-beautify`"


### PR DESCRIPTION
bump jsbeautify to 1.14.7 which is also used in the web version.